### PR TITLE
Fix passing of credentials from Action.fetch to ActionsFetcher

### DIFF
--- a/lib/salsa_labs/action.rb
+++ b/lib/salsa_labs/action.rb
@@ -22,7 +22,7 @@ module SalsaLabs
     end
 
     def self.fetch(credentials = {})
-      ActionsFetcher.new(credentials).fetch
+      ActionsFetcher.new({}, credentials).fetch
     end
 
   end

--- a/spec/salsa_labs/action_spec.rb
+++ b/spec/salsa_labs/action_spec.rb
@@ -62,6 +62,13 @@ describe SalsaLabs::Action do
 
       expect(actions_fetcher).to have_received(:fetch)
     end
+
+    it "passes the credentials to actions fetcher" do
+      SalsaLabs::Action.fetch(email: 'foo@bar.com', password: 'pass')
+
+      expect(SalsaLabs::ActionsFetcher).to have_received(:new).
+        with({}, {email: 'foo@bar.com', password: 'pass'})
+    end
   end
 
 end


### PR DESCRIPTION
ActionsFetcher takes filters as the first parameter, and credentials as
the second. The old code passed credentials as filters.
