### PR TITLE
Fix parsing of action attributes

### DIFF
--- a/lib/salsa_labs/actions_fetcher.rb
+++ b/lib/salsa_labs/actions_fetcher.rb
@@ -43,8 +43,8 @@ module SalsaLabs
 
       def attributes
         children.inject({}) do |memo, attribute|
-          memo[attribute.name.downcase] = attribute.text
-          attribute
+          memo[attribute.name.downcase] = attribute.text if attribute.element?
+          memo
         end
       end
 

--- a/spec/salsa_labs/actions_fetcher_spec.rb
+++ b/spec/salsa_labs/actions_fetcher_spec.rb
@@ -27,6 +27,15 @@ describe SalsaLabs::ActionsFetcher do
       expect(results).to be_a(Array)
       expect(results.first).to be_a(SalsaLabs::Action)
     end
+
+    it "parses the actions" do
+      action = SalsaLabs::ActionsFetcher.new.fetch.first
+
+      expect(action.action_key).to eq(6656)
+      expect(action.description).to eq("<p>&#160;</p>")
+      expect(action.title).to eq("My Action Title")
+      expect(action.reference_name).to eq("My TItle")
+    end
   end
 
 end


### PR DESCRIPTION
When parsing XML like this:

```
<item>
  <action_key>123</action_key>
  <title>Foo</title>
</item>
```

Nokogiri returns not only element nodes (item, action_key, title),
but also text nodes for the whitespace in between the tags.

The parsing code used to not to discriminate between the two types and
try to parse both the same way.
