### PR TITLE
Parse chapter_key in actions

### DIFF
--- a/lib/salsa_labs/action.rb
+++ b/lib/salsa_labs/action.rb
@@ -8,6 +8,10 @@ module SalsaLabs
       (attributes['action_key'] || 0).to_i
     end
 
+    def chapter_key
+      attributes['chapter_key'].to_i if attributes['chapter_key']
+    end
+
     def description
       attributes['description']
     end

--- a/spec/salsa_labs/action_spec.rb
+++ b/spec/salsa_labs/action_spec.rb
@@ -7,6 +7,7 @@ describe SalsaLabs::Action do
       'action_key' => '1234',
       'description' => 'Lengthy Description',
       'organization_key' => '90210',
+      'chapter_key' => '234',
       'reference_name' => 'A Good Reference',
       'title' => 'A Distinguished Title'
     }
@@ -17,6 +18,12 @@ describe SalsaLabs::Action do
   describe "#action_key" do
     it "returns the action_key attribute as an integer" do
       expect(action.action_key).to eq(1234)
+    end
+  end
+
+  describe "#chapter_key" do
+    it "returns the chapter_key attribute as an integer" do
+      expect(action.chapter_key).to eq(234)
     end
   end
 


### PR DESCRIPTION
An additional field that is required  to generate urls for actions.
